### PR TITLE
Prevent turn around death

### DIFF
--- a/main.c
+++ b/main.c
@@ -116,7 +116,7 @@ void acceptInput()
         }
     }
 
-    if (IsKeyPressed(KEY_A))
+    if (IsKeyPressed(KEY_A) && frameStartDirection != east)
     {
         if (snake[0].dir != east && snake[0].dir != west)
         {
@@ -124,7 +124,7 @@ void acceptInput()
         }
     }
 
-    if (IsKeyPressed(KEY_D))
+    if (IsKeyPressed(KEY_D) && frameStartDirection != west)
     {
         if (snake[0].dir != east && snake[0].dir != west)
         {


### PR DESCRIPTION
prevent the snake dying of a turn around by preventing direction to change from east to west or from west to eat in one frame