### PR TITLE
Custom build system setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 
 # ignore the app folder where the binaries are stored
 app
+
+# ignore the auto-generated sublime-workspace file
+c-snake-raylib.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ github: https://github.com/raysan5/raylib
 
 The CMake template I have used is (mostly) from a github gist, \
 which is linked in this video by the creator: https://www.youtube.com/watch?v=_i4wRjcp8eU
+
+The sublime text project file setup (along with the compile errors highlighting) is based \
+on a similar setup done by Karl Zylinksi for an Odin project in this video: https://www.youtube.com/watch?v=RF2MgVqfBV8

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+# build system for the project to run the cmake steps
+
+targetName="c_snake"
+
+echo "step 1: generate the make file..."
+result1=$(cmake -B build)
+
+if [[ $result1 =~ "errors occurred!" ]]; then
+	echo "step 1: failed, abort"
+	exit 1
+fi
+
+echo "step 2: build the target (and its dependencies)..."
+result2=$(cmake --build build)
+
+if ! [[ $result2 == *"Built target $targetName"* ]]; then
+	echo "step 2: failed, abort"
+	exit 1
+fi
+		
+echo "step 3: run the game!"
+./build/c_snake

--- a/c-snake-raylib.sublime-project
+++ b/c-snake-raylib.sublime-project
@@ -1,0 +1,15 @@
+{
+	"folders":
+	[
+		{
+			"path": "."
+		}
+	],
+	"build_systems":
+	[
+		{
+			"name": "c-snake-raylib-build",
+			"cmd": ["sh", "build.sh"],
+		}
+	]
+}


### PR DESCRIPTION
 - (Mac/Linux only, but should be easy to modify for windows) created a bash script as a single line command for building and running the whole thing 
 - created a sublime text project which uses the above build script as well as error highlighting.
 - The sublime text project file setup (along with the compile errors highlighting) is based 
on a similar setup done by Karl Zylinksi for an Odin project in this video: https://www.youtube.com/watch?v=RF2MgVqfBV8